### PR TITLE
feat: cleanup external oracle

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier-plugin-solidity": "^1.1.1"
   },
   "dependencies": {
-    "@bgd-labs/aave-cli": "^0.16.2",
+    "@bgd-labs/aave-cli": "^0.16.3",
     "catapulta-verify": "^1.1.1"
   }
 }

--- a/src/periphery/contracts/static-a-token/StataOracle.sol
+++ b/src/periphery/contracts/static-a-token/StataOracle.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.10;
 
-import {IPool} from '../../../core/contracts/interfaces/IPool.sol';
-import {IPoolAddressesProvider} from '../../../core/contracts/interfaces/IPoolAddressesProvider.sol';
-import {IAaveOracle} from '../../../core/contracts/interfaces/IAaveOracle.sol';
+import {IStaticATokenLM} from './interfaces/IStaticATokenLM.sol';
 import {IStataOracle} from './interfaces/IStataOracle.sol';
-import {IERC4626} from './interfaces/IERC4626.sol';
 
 /**
  * @title StataOracle
@@ -14,27 +11,15 @@ import {IERC4626} from './interfaces/IERC4626.sol';
  */
 contract StataOracle is IStataOracle {
   /// @inheritdoc IStataOracle
-  IPool public immutable POOL;
-  /// @inheritdoc IStataOracle
-  IAaveOracle public immutable AAVE_ORACLE;
-
-  constructor(IPoolAddressesProvider provider) {
-    POOL = IPool(provider.getPool());
-    AAVE_ORACLE = IAaveOracle(provider.getPriceOracle());
-  }
-
-  /// @inheritdoc IStataOracle
   function getAssetPrice(address asset) public view returns (uint256) {
-    address underlying = IERC4626(asset).asset();
-    return
-      (AAVE_ORACLE.getAssetPrice(underlying) * POOL.getReserveNormalizedIncome(underlying)) / 1e27;
+    return uint256(IStaticATokenLM(asset).latestAnswer());
   }
 
   /// @inheritdoc IStataOracle
   function getAssetsPrices(address[] calldata assets) external view returns (uint256[] memory) {
     uint256[] memory prices = new uint256[](assets.length);
     for (uint256 i = 0; i < assets.length; i++) {
-      prices[i] = getAssetPrice(assets[i]);
+      prices[i] = uint256(IStaticATokenLM(assets[i]).latestAnswer());
     }
     return prices;
   }

--- a/src/periphery/contracts/static-a-token/interfaces/IStataOracle.sol
+++ b/src/periphery/contracts/static-a-token/interfaces/IStataOracle.sol
@@ -1,20 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
-import {IPool} from '../../../../core/contracts/interfaces/IPool.sol';
-import {IAaveOracle} from '../../../../core/contracts/interfaces/IAaveOracle.sol';
-
 interface IStataOracle {
-  /**
-   * @return The pool used for fetching the rate on the aggregator oracle
-   */
-  function POOL() external view returns (IPool);
-
-  /**
-   * @return The aave oracle used for fetching the price of the underlying
-   */
-  function AAVE_ORACLE() external view returns (IAaveOracle);
-
   /**
    * @notice Returns the prices of an asset address
    * @param asset The asset address

--- a/tests/periphery/static-a-token/StataOracle.t.sol
+++ b/tests/periphery/static-a-token/StataOracle.t.sol
@@ -10,7 +10,7 @@ contract StataOracleTest is BaseTest {
 
   function setUp() public override {
     super.setUp();
-    oracle = new StataOracle(contracts.poolAddressesProvider);
+    oracle = new StataOracle();
 
     vm.prank(address(roleList.marketOwner));
     contracts.poolConfiguratorProxy.setSupplyCap(UNDERLYING, 1_000_000);

--- a/tests/utils/DiffUtils.sol
+++ b/tests/utils/DiffUtils.sol
@@ -22,7 +22,7 @@ contract DiffUtils is Test {
 
     string[] memory inputs = new string[](7);
     inputs[0] = 'npx';
-    inputs[1] = '@bgd-labs/aave-cli@^0.16.2';
+    inputs[1] = '@bgd-labs/aave-cli@^0.16.3';
     inputs[2] = 'diff-snapshots';
     inputs[3] = beforePath;
     inputs[4] = afterPath;


### PR DESCRIPTION
Not sure if anyone relies on that, but just i case cleaning it up as well.

I think could also be reasonable to just remove completely as with `latestAnswer` on the token itself, seems a bit unncessary (the only added feature is a more or less generic chainlinkaggregator compatible multicall)