### PR TITLE
Changes on stata initializations, to follow more strict guidelines

### DIFF
--- a/src/periphery/contracts/static-a-token/ERC20AaveLMUpgradeable.sol
+++ b/src/periphery/contracts/static-a-token/ERC20AaveLMUpgradeable.sol
@@ -41,8 +41,13 @@ abstract contract ERC20AaveLMUpgradeable is ERC20Upgradeable, IERC20AaveLM {
     INCENTIVES_CONTROLLER = rewardsController;
   }
 
-  function __ERC20AaveLM_init(address referenceAsset_) internal onlyInitializing {
+  function __ERC20AaveLM_init(
+    address referenceAsset_,
+    string calldata staticATokenName,
+    string calldata staticATokenSymbol
+  ) internal onlyInitializing {
     __ERC20AaveLM_init_unchained(referenceAsset_);
+    __ERC20_init_unchained(staticATokenName, staticATokenSymbol);
   }
   function __ERC20AaveLM_init_unchained(address referenceAsset_) internal onlyInitializing {
     ERC20AaveLMStorage storage $ = _getERC20AaveLMStorage();

--- a/src/periphery/contracts/static-a-token/ERC20AaveLMUpgradeable.sol
+++ b/src/periphery/contracts/static-a-token/ERC20AaveLMUpgradeable.sol
@@ -11,7 +11,8 @@ import {IERC20AaveLM} from './interfaces/IERC20AaveLM.sol';
 
 /**
  * @title ERC20AaveLMUpgradeable.sol
- * @notice Wrapper smart contract that supports tracking and claiming liquidity mining rewards from the Aave system.
+ * @notice Wrapper smart contract that supports tracking and claiming liquidity mining rewards from the Aave system
+ * @dev ERC20 extension, so ERC20 initialization should be done by the children contract/s
  * @author BGD labs
  */
 abstract contract ERC20AaveLMUpgradeable is ERC20Upgradeable, IERC20AaveLM {
@@ -41,13 +42,8 @@ abstract contract ERC20AaveLMUpgradeable is ERC20Upgradeable, IERC20AaveLM {
     INCENTIVES_CONTROLLER = rewardsController;
   }
 
-  function __ERC20AaveLM_init(
-    address referenceAsset_,
-    string calldata staticATokenName,
-    string calldata staticATokenSymbol
-  ) internal onlyInitializing {
+  function __ERC20AaveLM_init(address referenceAsset_) internal onlyInitializing {
     __ERC20AaveLM_init_unchained(referenceAsset_);
-    __ERC20_init_unchained(staticATokenName, staticATokenSymbol);
   }
   function __ERC20AaveLM_init_unchained(address referenceAsset_) internal onlyInitializing {
     ERC20AaveLMStorage storage $ = _getERC20AaveLMStorage();

--- a/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
+++ b/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
@@ -16,6 +16,7 @@ import {IERC4626StataToken} from './interfaces/IERC4626StataToken.sol';
  * @title ERC4626StataTokenUpgradeable.sol.sol
  * @notice Wrapper smart contract that allows to deposit tokens on the Aave protocol and receive
  * a token which balance doesn't increase automatically, but uses an ever-increasing exchange rate.
+ * @dev ERC20 extension, so ERC20 initialization should be done by the children contract/s
  * @author BGD labs
  */
 abstract contract ERC4626StataTokenUpgradeable is ERC4626Upgradeable, IERC4626StataToken {
@@ -50,18 +51,9 @@ abstract contract ERC4626StataTokenUpgradeable is ERC4626Upgradeable, IERC4626St
     POOL_ADDRESSES_PROVIDER = pool.ADDRESSES_PROVIDER();
   }
 
-  function __ERC4626StataToken_init(
-    address newAToken,
-    string calldata staticATokenName,
-    string calldata staticATokenSymbol
-  ) internal onlyInitializing {
+  function __ERC4626StataToken_init(address newAToken) internal onlyInitializing {
     IERC20 aTokenUnderlying = __ERC4626StataToken_init_unchained(newAToken);
-
-    /// @notice __ERC4626_init doesn't init the ERC20Upgradeable, but following the init
-    /// procedures, this function should initialize everything required for this contract
-    /// to be completely initialized, including the inheritance chain
     __ERC4626_init_unchained(aTokenUnderlying);
-    __ERC20_init_unchained(staticATokenName, staticATokenSymbol);
   }
 
   function __ERC4626StataToken_init_unchained(

--- a/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
+++ b/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
@@ -21,7 +21,7 @@ import {IERC4626StataToken} from './interfaces/IERC4626StataToken.sol';
 abstract contract ERC4626StataTokenUpgradeable is ERC4626Upgradeable, IERC4626StataToken {
   using Math for uint256;
 
-  /// @custom:storage-location erc7201:aave-dao.storage.Stata4626
+  /// @custom:storage-location erc7201:aave-dao.storage.ERC4626StataToken
   struct ERC4626StataTokenStorage {
     IERC20 _aToken;
   }
@@ -50,23 +50,35 @@ abstract contract ERC4626StataTokenUpgradeable is ERC4626Upgradeable, IERC4626St
     POOL_ADDRESSES_PROVIDER = pool.ADDRESSES_PROVIDER();
   }
 
-  function __ERC4626StataToken_init(address newAToken) internal onlyInitializing {
-    // TODO: maybe to do some movements here
-    __ERC4626StataToken_init_unchained(newAToken);
+  function __ERC4626StataToken_init(
+    address newAToken,
+    string calldata staticATokenName,
+    string calldata staticATokenSymbol
+  ) internal onlyInitializing {
+    IERC20 aTokenUnderlying = __ERC4626StataToken_init_unchained(newAToken);
+
+    /// @notice __ERC4626_init doesn't init the ERC20Upgradeable, but following the init
+    /// procedures, this function should initialize everything required for this contract
+    /// to be completely initialized, including the inheritance chain
+    __ERC4626_init_unchained(aTokenUnderlying);
+    __ERC20_init_unchained(staticATokenName, staticATokenSymbol);
   }
 
-  function __ERC4626StataToken_init_unchained(address newAToken) internal onlyInitializing {
+  function __ERC4626StataToken_init_unchained(
+    address newAToken
+  ) internal onlyInitializing returns (IERC20) {
     // sanity check, to be sure that we support that version of the aToken
     address poolOfAToken = IAToken(newAToken).POOL();
     if (poolOfAToken != address(POOL)) revert PoolAddressMismatch(poolOfAToken);
 
     IERC20 aTokenUnderlying = IERC20(IAToken(newAToken).UNDERLYING_ASSET_ADDRESS());
-    __ERC4626_init(aTokenUnderlying);
 
     ERC4626StataTokenStorage storage $ = _getERC4626StataTokenStorage();
     $._aToken = IERC20(newAToken);
 
     SafeERC20.forceApprove(aTokenUnderlying, address(POOL), type(uint256).max);
+
+    return aTokenUnderlying;
   }
 
   ///@inheritdoc IERC4626StataToken

--- a/src/periphery/contracts/static-a-token/StataTokenV2.sol
+++ b/src/periphery/contracts/static-a-token/StataTokenV2.sol
@@ -34,15 +34,10 @@ contract StataTokenV2 is
     string calldata staticATokenName,
     string calldata staticATokenSymbol
   ) external initializer {
-    /// @notice __ERC4626StataToken_init will also init ERC20
-    __ERC4626StataToken_init(aToken, staticATokenName, staticATokenSymbol);
-
+    __ERC20_init(staticATokenName, staticATokenSymbol);
     __ERC20Permit_init(staticATokenName);
-
-    /// @notice using init_unchained because we have already initialized ERC20
-    /// with __ERC4626StataToken_init, so we want only to init ERC20AaveLM
     __ERC20AaveLM_init_unchained(aToken);
-
+    __ERC4626StataToken_init(aToken);
     __Pausable_init();
   }
 

--- a/src/periphery/contracts/static-a-token/StataTokenV2.sol
+++ b/src/periphery/contracts/static-a-token/StataTokenV2.sol
@@ -34,10 +34,15 @@ contract StataTokenV2 is
     string calldata staticATokenName,
     string calldata staticATokenSymbol
   ) external initializer {
-    __ERC20_init(staticATokenName, staticATokenSymbol);
+    /// @notice __ERC4626StataToken_init will also init ERC20
+    __ERC4626StataToken_init(aToken, staticATokenName, staticATokenSymbol);
+
     __ERC20Permit_init(staticATokenName);
-    __ERC20AaveLM_init(aToken);
-    __ERC4626StataToken_init(aToken);
+
+    /// @notice using init_unchained because we have already initialized ERC20
+    /// with __ERC4626StataToken_init, so we want only to init ERC20AaveLM
+    __ERC20AaveLM_init_unchained(aToken);
+
     __Pausable_init();
   }
 
@@ -58,6 +63,8 @@ contract StataTokenV2 is
   }
 
   function decimals() public view override(ERC20Upgradeable, ERC4626Upgradeable) returns (uint8) {
+    /// @notice The initialization of ERC4626Upgradeable already assures that decimal are
+    /// the same as the underlying asset of the StataTokenV2, e.g. decimals of WETH for stataWETH
     return ERC4626Upgradeable.decimals();
   }
 

--- a/src/periphery/contracts/static-a-token/StataTokenV2.sol
+++ b/src/periphery/contracts/static-a-token/StataTokenV2.sol
@@ -36,7 +36,7 @@ contract StataTokenV2 is
   ) external initializer {
     __ERC20_init(staticATokenName, staticATokenSymbol);
     __ERC20Permit_init(staticATokenName);
-    __ERC20AaveLM_init_unchained(aToken);
+    __ERC20AaveLM_init(aToken);
     __ERC4626StataToken_init(aToken);
     __Pausable_init();
   }


### PR DESCRIPTION
The rules followed are:
- **Both ERC4626StataTokenUpgradeable and ERC20AaveLMUpgradeable are ERC20 extensions**. That means that their `_init` functions initialise everything in their inheritance chain, but not ERC20.
- `_init_unchained` methods change to pure initialisation of the current contract, no matter the parents.
- **`StataTokenV2` is the "final" contract**. So it initialises ERC20, together with all linearised ERC20 extensions in its inheritance chain.