### PR TITLE
Fix/total assets

### DIFF
--- a/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
+++ b/src/periphery/contracts/static-a-token/ERC4626StataTokenUpgradeable.sol
@@ -133,6 +133,11 @@ abstract contract ERC4626StataTokenUpgradeable is ERC4626Upgradeable, IERC4626St
   }
 
   ///@inheritdoc IERC4626
+  function totalAssets() public view override returns (uint256) {
+    return _convertToAssets(totalSupply(), Math.Rounding.Floor);
+  }
+
+  ///@inheritdoc IERC4626
   function maxRedeem(address owner) public view override returns (uint256) {
     DataTypes.ReserveData memory reserveData = POOL.getReserveDataExtended(asset());
 

--- a/tests/periphery/static-a-token/ERC4626StataTokenUpgradeable.t.sol
+++ b/tests/periphery/static-a-token/ERC4626StataTokenUpgradeable.t.sol
@@ -74,6 +74,7 @@ contract ERC4626StataTokenUpgradeableTest is TestnetProcedures {
     assertEq(erc4626Upgradeable.balanceOf(receiver), shares);
     assertEq(IERC20(aToken).balanceOf(address(erc4626Upgradeable)), env.amount);
     assertEq(IERC20(aToken).balanceOf(user), 0);
+    assertEq(erc4626Upgradeable.totalAssets(), env.amount);
   }
 
   function test_depositATokens_self() external {

--- a/tests/periphery/static-a-token/ERC4626StataTokenUpgradeable.t.sol
+++ b/tests/periphery/static-a-token/ERC4626StataTokenUpgradeable.t.sol
@@ -60,6 +60,10 @@ contract ERC4626StataTokenUpgradeableTest is TestnetProcedures {
     assertEq(erc4626Upgradeable.previewRedeem(shares), assets);
   }
 
+  function test_totalAssets_shouldbeZeroOnZeroSupply() external {
+    assertEq(erc4626Upgradeable.totalAssets(), 0);
+  }
+
   // ### DEPOSIT TESTS ###
   function test_depositATokens(uint128 assets, address receiver) public {
     _validateReceiver(receiver);


### PR DESCRIPTION
Currently totalAssets returns `underlying.balanceOf(stata)` which will always be zero.

In the previous version we returned `aToken.balanceOf(stata)` which ofc works, but is suspectable to:
a) donations
b) if ever an aToken would be used as rewardToken `collectAndUpdateRewards` would claim the aTokens to the contract, altering totalAssets

Therefore I opted for just reversing the math to return the totalAssets based on exchangeRate + totalSupply.