### PR TITLE
fix: weth gateway gas griefing

### DIFF
--- a/src/contracts/helpers/WrappedTokenGatewayV3.sol
+++ b/src/contracts/helpers/WrappedTokenGatewayV3.sol
@@ -137,7 +137,9 @@ contract WrappedTokenGatewayV3 is IWrappedTokenGatewayV3, Ownable {
       amountToWithdraw = userBalance;
     }
     // permit `amount` rather than `amountToWithdraw` to make it easier for front-ends and integrators
-    aWETH.permit(msg.sender, address(this), amount, deadline, permitV, permitR, permitS);
+    try
+      aWETH.permit(msg.sender, address(this), amount, deadline, permitV, permitR, permitS)
+    {} catch {}
     aWETH.transferFrom(msg.sender, address(this), amountToWithdraw);
     POOL.withdraw(address(WETH), amountToWithdraw, address(this));
     WETH.withdraw(amountToWithdraw);

--- a/tests/helpers/WrappedTokenGateway.t.sol
+++ b/tests/helpers/WrappedTokenGateway.t.sol
@@ -227,6 +227,45 @@ contract WrappedTokenGatewayTests is TestnetProcedures {
     assertEq(alice.balance, userEthBalanceBefore + userATokenBalance);
   }
 
+  function test_withdrawEth_permit_frontrunRegression() public {
+    test_depositNativeEthInPool();
+
+    uint256 withdrawAmount = 0.6e18;
+
+    EIP712SigUtils.Permit memory permit = EIP712SigUtils.Permit({
+      owner: alice,
+      spender: address(wrappedTokenGatewayV3),
+      value: withdrawAmount,
+      nonce: 0,
+      deadline: block.timestamp + 1 days
+    });
+    bytes32 digest = EIP712SigUtils.getTypedDataHash(
+      permit,
+      bytes(aWEth.name()),
+      bytes('1'),
+      address(aWEth)
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(alicePrivateKey, digest);
+
+    uint256 userEthBalanceBefore = alice.balance;
+
+    vm.prank(alice);
+    aWEth.permit(permit.owner, permit.spender, permit.value, permit.deadline, v, r, s);
+
+    // should not revert if permit is already executed
+    vm.prank(alice);
+    wrappedTokenGatewayV3.withdrawETHWithPermit(
+      report.poolProxy,
+      withdrawAmount,
+      alice,
+      permit.deadline,
+      v,
+      r,
+      s
+    );
+  }
+
   function test_withdrawEth_full() public {
     uint256 fullWithdraw = depositSize;
 


### PR DESCRIPTION
There is a well known issue regarding the griefing of permits.
Frontrunning a permit can result in the txn relying on the permit to revert (as due to nonce the permit can not be executed twice). While this issue is fixed in other situations, on the weth gateway one usage was overlooked.

This pr wraps the permit in a try..catch, to work around the issue.